### PR TITLE
V0.2.0 snapshot

### DIFF
--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/S3Client.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/S3Client.kt
@@ -330,61 +330,52 @@ interface S3Client {
    *
    * @param region Optional region value for the S3 operation.
    *
-   * @return Flag indicating whether the target bucket was deleted.  `true` if
-   * the bucket existed and was deleted, `false` if the bucket did not exist.
-   *
    * @throws BucketNotEmptyException If the target bucket is not empty.
    *
    * @throws S34kException If an implementation specific exception is thrown.
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteBucket(name: BucketName, region: String? = null): Boolean
+  fun deleteBucket(name: BucketName, region: String? = null)
 
   /**
    * Deletes the target bucket from the S3 instance.
    *
    * @param action Action used to configure the S3 operation parameters.
    *
-   * @return Flag indicating whether the target bucket was deleted.  `true` if
-   * the bucket existed and was deleted, `false` if the bucket did not exist.
-   *
    * @throws BucketNotEmptyException If the target bucket is not empty.
    *
    * @throws S34kException If an implementation specific exception is thrown.
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteBucket(action: S3BucketDeleteParams.() -> Unit): Boolean
+  fun deleteBucket(action: S3BucketDeleteParams.() -> Unit)
 
   /**
    * Deletes the target bucket from the S3 instance.
    *
    * @param params S3 operation parameters.
    *
-   * @return Flag indicating whether the target bucket was deleted.  `true` if
-   * the bucket existed and was deleted, `false` if the bucket did not exist.
-   *
    * @throws BucketNotEmptyException If the target bucket is not empty.
    *
    * @throws S34kException If an implementation specific exception is thrown.
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteBucket(params: S3BucketDeleteParams): Boolean
+  fun deleteBucket(params: S3BucketDeleteParams)
 
   // endregion
 
   // region Delete Bucket Recursive
 
   // TODO: Document me
-  fun deleteBucketRecursive(name: BucketName, region: String? = null): Boolean
+  fun deleteBucketRecursive(name: BucketName, region: String? = null)
 
   // TODO: Document me
-  fun deleteBucketRecursive(action: S3ClientRecursiveBucketDeleteParams.() -> Unit): Boolean
+  fun deleteBucketRecursive(action: S3ClientRecursiveBucketDeleteParams.() -> Unit)
 
   // TODO: Document me
-  fun deleteBucketRecursive(params: S3ClientRecursiveBucketDeleteParams): Boolean
+  fun deleteBucketRecursive(params: S3ClientRecursiveBucketDeleteParams)
 
   // endregion Delete Bucket Recursive
 }

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/S3DeleteRequestParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/S3DeleteRequestParams.kt
@@ -18,14 +18,10 @@ import org.veupathdb.lib.s3.s34k.requests.`object`.S3ObjectDeleteParams
 interface S3DeleteRequestParams : S3RegionRequestParams {
 
   /**
-   * Callback that will be executed on successful completion of the S3
+   * Optional callback that will be executed on successful completion of the S3
    * operation.
-   *
-   * The callback will be passed the result of the operation, `true` meaning the
-   * target previously existed and has been deleted, `false` meaning the target
-   * did not exist at the time of the operation.
    */
-  var callback: ((Boolean) -> Unit)?
+  var callback: (() -> Unit)?
 
   /**
    * Converts this generalized delete request into a bucket delete request.

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3ClientRecursiveBucketDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3ClientRecursiveBucketDeleteParams.kt
@@ -29,4 +29,10 @@ interface S3ClientRecursiveBucketDeleteParams : S3RecursiveBucketDeleteParams {
    * when the request is attempted.
    */
   var bucketName: BucketName?
+
+  /**
+   * Optional callback that will be executed on successful completion of the S3
+   * operation.
+   */
+  var callback: (() -> Unit)?
 }

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3ClientRecursiveBucketDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3ClientRecursiveBucketDeleteParams.kt
@@ -29,10 +29,4 @@ interface S3ClientRecursiveBucketDeleteParams : S3RecursiveBucketDeleteParams {
    * when the request is attempted.
    */
   var bucketName: BucketName?
-
-  /**
-   * Optional callback that will be executed on successful completion of the S3
-   * operation.
-   */
-  var callback: (() -> Unit)?
 }

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3RecursiveBucketDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/bucket/recursive/S3RecursiveBucketDeleteParams.kt
@@ -61,5 +61,11 @@ interface S3RecursiveBucketDeleteParams : S3RegionRequestParams {
    * Bucket delete operation parameters.
    */
   val bucketDelete: S3RBDBucketDeleteParams
+
+  /**
+   * Optional callback that will be executed on successful completion of the S3
+   * operation.
+   */
+  var callback: (() -> Unit)?
 }
 

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/client/S3BucketDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/client/S3BucketDeleteParams.kt
@@ -14,12 +14,6 @@ interface S3BucketDeleteParams : S3BucketRequestParams {
   /**
    * Optional callback that will be executed on successful completion of the S3
    * operation.
-   *
-   * This callback will be passed a boolean flag indicating whether the target
-   * bucket was deleted.  `true` indicates that the bucket existed in the store
-   * at the time of the operation and is now deleted, `false` indicates that the
-   * bucket had already been removed from the store at the time this operation
-   * was run.
    */
-  var callback: ((deleted: Boolean) -> Unit)?
+  var callback: (() -> Unit)?
 }

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/object/S3ObjectDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/object/S3ObjectDeleteParams.kt
@@ -12,10 +12,6 @@ interface S3ObjectDeleteParams : S3ObjectRequestParams {
   /**
    * Optional callback that will be executed on successful completion of the S3
    * operation.
-   *
-   * This callback will be passed a boolean flag indicating whether the file was
-   * deleted.  `true` means the file previously existed, and was deleted.
-   * `false` means the file did not exist at the time the request was made.
    */
-  var callback: ((Boolean) -> Unit)?
+  var callback: (() -> Unit)?
 }

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/object/directory/S3DirectoryDeleteParams.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/requests/object/directory/S3DirectoryDeleteParams.kt
@@ -14,13 +14,8 @@ interface S3DirectoryDeleteParams : S3ObjectRequestParams {
   /**
    * Optional callback that will be executed on successful completion of the
    * S3 operation.
-   *
-   * This callback will be passed a boolean flag indicating whether the
-   * directory existed before the delete operation was called.  `true` indicates
-   * the directory did exist but has now been deleted, `false` indicates the
-   * directory did not exist at the time the delete operation was executed.
    */
-  var callback: ((deleted: Boolean) -> Unit)?
+  var callback: (() -> Unit)?
 
   /**
    * Whether to delete this directory recursively (including all contents)

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/response/bucket/S3Bucket.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/response/bucket/S3Bucket.kt
@@ -70,9 +70,6 @@ interface S3Bucket {
   /**
    * Deletes this bucket.
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
-   *
    * @throws BucketNotEmptyException If this bucket is not empty and must be
    * cleared before deletion.
    *
@@ -82,16 +79,13 @@ interface S3Bucket {
    *
    * @see deleteRecursive
    */
-  fun delete(): Boolean
+  fun delete()
 
   /**
    * Deletes this bucket with the operation configured by the given action.
    *
    * @param action Action used to configure the S3 operation.
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
-   *
    * @throws InvalidRequestConfigException If the S3 operation parameters are
    * missing required fields or otherwise incorrectly configured.
    *
@@ -104,16 +98,13 @@ interface S3Bucket {
    *
    * @see deleteRecursive
    */
-  fun delete(action: S3DeleteRequestParams.() -> Unit): Boolean
+  fun delete(action: S3DeleteRequestParams.() -> Unit)
 
   /**
    * Deletes this bucket with the operation configured by the given params.
    *
    * @param params S3 operation parameters.
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
-   *
    * @throws InvalidRequestConfigException If the S3 operation parameters are
    * missing required fields or otherwise incorrectly configured.
    *
@@ -126,7 +117,7 @@ interface S3Bucket {
    *
    * @see deleteRecursive
    */
-  fun delete(params: S3DeleteRequestParams): Boolean
+  fun delete(params: S3DeleteRequestParams)
 
   // endregion Delete
 
@@ -143,9 +134,6 @@ interface S3Bucket {
    * 2. Delete all the objects from the bucket.
    * 3. Delete the bucket itself.
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
-   *
    * @throws RecursiveBucketDeleteError If an error occurs while attempting to
    * delete the bucket, or it's contained objects.
    *
@@ -155,16 +143,21 @@ interface S3Bucket {
    *
    * @see delete
    */
-  fun deleteRecursive(): Boolean
+  fun deleteRecursive()
 
   /**
    * Recursively deletes this bucket and all its contents with the operation
    * configured by the given action.
    *
-   * @param action Action used to configure the S3 operation.
+   * This operation happens in 3 phases which can be configured independently
+   * using the [S3RecursiveBucketDeleteParams] class.
+   * The 3 phases are:
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
+   * 1. Fetch a list of all the objects in the bucket.
+   * 2. Delete all the objects from the bucket.
+   * 3. Delete the bucket itself.
+   *
+   * @param action Action used to configure the S3 operation.
    *
    * @throws RecursiveBucketDeleteError If an error occurs while attempting to
    * delete the bucket, or it's contained objects.
@@ -175,16 +168,21 @@ interface S3Bucket {
    *
    * @see delete
    */
-  fun deleteRecursive(action: S3RecursiveBucketDeleteParams.() -> Unit): Boolean
+  fun deleteRecursive(action: S3RecursiveBucketDeleteParams.() -> Unit)
 
   /**
    * Recursively deletes this bucket and all its contents with the operation
    * configured by the given params.
    *
-   * @param params S3 operation parameters.
+   * This operation happens in 3 phases which can be configured independently
+   * using the [S3RecursiveBucketDeleteParams] class.
+   * The 3 phases are:
    *
-   * @return Whether the bucket was deleted.  `true` if the bucket previously
-   * existed and has been deleted, `false` if the bucket did not exist.
+   * 1. Fetch a list of all the objects in the bucket.
+   * 2. Delete all the objects from the bucket.
+   * 3. Delete the bucket itself.
+   *
+   * @param params S3 operation parameters.
    *
    * @throws RecursiveBucketDeleteError If an error occurs while attempting to
    * delete the bucket, or it's contained objects.
@@ -195,7 +193,7 @@ interface S3Bucket {
    *
    * @see delete
    */
-  fun deleteRecursive(params: S3RecursiveBucketDeleteParams): Boolean
+  fun deleteRecursive(params: S3RecursiveBucketDeleteParams)
 
   // endregion
 
@@ -1184,25 +1182,19 @@ interface S3Bucket {
    *
    * @param path Path to the target object that should be deleted.
    *
-   * @return `true` if the object previously existed and has now been deleted,
-   * `false` if the file already did not exist at the time of this operation.
-   *
    * @throws BucketNotFoundException If this bucket no longer exists.
    *
    * @throws S34kException If an implementation specific exception is thrown.
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteObject(path: String): Boolean
+  fun deleteObject(path: String)
 
   /**
    * Deletes the configured target object from this bucket.
    *
    * @param action Action used to configure the S3 operation.
    *
-   * @return `true` if the object previously existed and has now been deleted,
-   * `false` if the file already did not exist at the time of this operation.
-   *
    * @throws InvalidRequestConfigException If the S3 operation parameters are
    * missing required fields or otherwise incorrectly configured.
    *
@@ -1212,16 +1204,13 @@ interface S3Bucket {
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteObject(action: S3ObjectDeleteParams.() -> Unit): Boolean
+  fun deleteObject(action: S3ObjectDeleteParams.() -> Unit)
 
   /**
    * Deletes the configured target object from this bucket.
    *
    * @param params S3 operation parameters.
    *
-   * @return `true` if the object previously existed and has now been deleted,
-   * `false` if the file already did not exist at the time of this operation.
-   *
    * @throws InvalidRequestConfigException If the S3 operation parameters are
    * missing required fields or otherwise incorrectly configured.
    *
@@ -1231,7 +1220,7 @@ interface S3Bucket {
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteObject(params: S3ObjectDeleteParams): Boolean
+  fun deleteObject(params: S3ObjectDeleteParams)
 
   // endregion Delete Object
 
@@ -1266,9 +1255,6 @@ interface S3Bucket {
    * set to `false` and the directory is not empty, a [DirectoryNotEmptyError]
    * exception will be thrown.
    *
-   * @return `true` if the directory previously existed and was deleted, `false`
-   * if the directory did not exist at the time this method was called.
-   *
    * @throws BucketNotFoundException If this bucket no longer exists.
    *
    * @throws DirectoryNotEmptyError If the target directory is not empty and
@@ -1281,7 +1267,7 @@ interface S3Bucket {
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteDirectory(path: String, recursive: Boolean = true): Boolean
+  fun deleteDirectory(path: String, recursive: Boolean = true)
 
   /**
    * Deletes the target directory from this bucket with the operation configured
@@ -1293,9 +1279,6 @@ interface S3Bucket {
    *
    * @param action Action used to configure the S3 operation.
    *
-   * @return `true` if the directory previously existed and was deleted, `false`
-   * if the directory did not exist at the time this method was called.
-   *
    * @throws BucketNotFoundException If this bucket no longer exists.
    *
    * @throws DirectoryNotEmptyError If the target directory is not empty and
@@ -1308,7 +1291,7 @@ interface S3Bucket {
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteDirectory(action: S3DirectoryDeleteParams.() -> Unit): Boolean
+  fun deleteDirectory(action: S3DirectoryDeleteParams.() -> Unit)
 
   /**
    * Deletes the target directory from this bucket with the operation configured
@@ -1320,9 +1303,6 @@ interface S3Bucket {
    *
    * @param params S3 operation parameters.
    *
-   * @return `true` if the directory previously existed and was deleted, `false`
-   * if the directory did not exist at the time this method was called.
-   *
    * @throws BucketNotFoundException If this bucket no longer exists.
    *
    * @throws DirectoryNotEmptyError If the target directory is not empty and
@@ -1335,7 +1315,7 @@ interface S3Bucket {
    * The implementation specific exception will be set to the thrown exception's
    * 'cause' value.
    */
-  fun deleteDirectory(params: S3DirectoryDeleteParams): Boolean
+  fun deleteDirectory(params: S3DirectoryDeleteParams)
 
   // endregion Delete Directory
 

--- a/src/main/kotlin/org/veupathdb/lib/s3/s34k/response/object/S3Object.kt
+++ b/src/main/kotlin/org/veupathdb/lib/s3/s34k/response/object/S3Object.kt
@@ -27,34 +27,22 @@ interface S3Object : S3ObjectResponse {
 
   /**
    * Deletes the current object from the S3 store (if it still exists).
-   *
-   * @return Flag indicating if the object was deleted from the store.  `true`
-   * if the object existed and was deleted, `false` if the
-   * object did not exist.
    */
-  fun delete(): Boolean
+  fun delete()
 
   /**
    * Deletes the current object from the S3 store (if it still exists).
    *
    * @param action Action used to configure the S3 operation.
-   *
-   * @return Flag indicating if the object was deleted from the store.  `true`
-   * if the object existed and was deleted, `false` if the
-   * object did not exist.
    */
-  fun delete(action: S3DeleteRequestParams.() -> Unit): Boolean
+  fun delete(action: S3DeleteRequestParams.() -> Unit)
 
   /**
    * Deletes the current object from the S3 store (if it still exists).
    *
    * @param params S3 operation parameters.
-   *
-   * @return Flag indicating if the object was deleted from the store.  `true`
-   * if the object existed and was deleted, `false` if the
-   * object did not exist.
    */
-  fun delete(params: S3DeleteRequestParams): Boolean
+  fun delete(params: S3DeleteRequestParams)
 
   // endregion
 


### PR DESCRIPTION
As S3 operations are prone to race conditions so this value can't be trusted.

Additionally, in some cases, having to test for this adds complexity to the implementation.

Resolves #6